### PR TITLE
Add manual action for deploying to Vercel

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -35,14 +35,24 @@ jobs:
           echo '{ "version": 3 }' > .vercel/output/config.json
 
       - name: Deploy to Vercel
+        id: deploy
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
         run: |
-          if [[ ${{ github.ref }} == 'refs/heads/main' ]]; then
-            vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+          if [[ $GITHUB_REF == 'refs/heads/main' ]]; then
+            DEPLOY_URL=$(vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }} | tail -n1)
           else
             BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//-/g')
-            vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} --name $BRANCH_NAME
+            DEPLOY_URL=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} --name $BRANCH_NAME | tail -n1)
           fi
+          echo "VERCEL_URL=$DEPLOY_URL" >> $GITHUB_ENV
+          echo "::set-output name=vercel_url::$DEPLOY_URL"
+
+      - name: Output Vercel Deployment URL
+        run: echo "Deployed to $VERCEL_URL"
+
+      - name: Add Deployment URL to Summary
+        run: |
+          echo "🚀 Deployment URL: [$VERCEL_URL]($VERCEL_URL)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -16,7 +16,8 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-
+      - name: Install dependencies
+        run: bun install
       - name: Build project
         run: bun run build
 

--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -3,7 +3,7 @@ name: Build and Deploy to Vercel
 on:
   push:
     branches:
-      - '*'
+      - '**'
 
 jobs:
   build-and-deploy:
@@ -16,7 +16,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-          
+
       - name: Install dependencies
         run: bun install
 

--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -16,8 +16,10 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+          
       - name: Install dependencies
         run: bun install
+
       - name: Build project
         run: bun run build
 

--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Initialize Vercel
         run: |
-          npm i -g vercel
+          bun add -g vercel
           vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Prepare for Vercel deployment


### PR DESCRIPTION
When deploying automatically on Vercel, the built output was quite problematic - I think it's because their version of Bun is < 1.2.3. Added this manual workflow to push preview releases when pushing on a branch, and to push to production when pushing on main.